### PR TITLE
fix: include $server_port in odk proxy pass block

### DIFF
--- a/local-setup/nginx/sites-enabled/odk.conf
+++ b/local-setup/nginx/sites-enabled/odk.conf
@@ -34,7 +34,7 @@ server {
   location / {
     proxy_pass              http://odk.aether.local:8002;
 
-    proxy_set_header        Host               $host;
+    proxy_set_header        Host               $host:$server_port;
     proxy_set_header        X-Real-IP          $remote_addr;
     proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Host   $host:8443;

--- a/local-setup/nginx/sites-enabled/odk.conf
+++ b/local-setup/nginx/sites-enabled/odk.conf
@@ -34,7 +34,7 @@ server {
   location / {
     proxy_pass              http://odk.aether.local:8002;
 
-    proxy_set_header        Host               $host:$server_port;
+    proxy_set_header        Host               $host:8443;
     proxy_set_header        X-Real-IP          $remote_addr;
     proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Host   $host:8443;


### PR DESCRIPTION
Without $server_port, the /formList endpoint in aether-odk
will not include the port number. This means that ODK
Collect will receive invalid form URLs and will not be able
to download any forms.