### PR TITLE
fix: docker-compose configuration for local development

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -12,7 +12,7 @@ services:
       PGUSER: postgres
     healthcheck:
       test: pg_isready
-      interval: 1s
+      interval: 5s
       timeout: 3s
       retries: 30
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -61,8 +61,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      kernel:
-        condition: service_started
     networks:
       gather_local:
         aliases:
@@ -82,12 +80,16 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      kernel:
-        condition: service_started
     networks:
       gather_local:
         aliases:
           - ui.aether.local
+
+  ui-assets:
+    extends:
+      file: ${AETHER_PATH:-../aether}/docker-compose-base.yml
+      service: ui-assets-base
+
 
   # ---------------------------------
   # Gather Assets container
@@ -112,10 +114,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      kernel:
-        condition: service_started
-      odk:
-        condition: service_started
     networks:
       gather_local:
         aliases:


### PR DESCRIPTION
Background: the docker-compose configuration we are using for developing gather locally intermittently fails; nginx might fail to start, or, if it starts, we get `504 Gateway Timeout` when attempting to access e.g. odk. In addition, the initial database migrations of the django projects sometimes fail due to lack of database connection.     

Increase health check interval for db container.

Add ui-assets service to local compose file.

Make each django project container depend only on "db".

How to test (**WARNING** this will wipe your local data):
1. First, make sure that your aether repo is located at `<gather-repo-location>/../aether` and that commit `5a522d8a482222448a33d80dffcc36889bce4385` (current develop) is checked out.

2. Run:
```
sudo rm -r .persistent_data; docker stop $(docker ps -aq); docker rm --force $(docker ps -aq); docker volume rm $(docker volume ls -qf dangling=true); docker-compose -f docker-compose-local.yml up
```

3. Once all containers have started, check that you can access both Aether-UI and Gather-UI in the browser.