### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/app/conf/pip/requirements.txt
+++ b/app/conf/pip/requirements.txt
@@ -18,14 +18,14 @@ coverage==4.5.1
 Django==2.1.1
 django-cas-ng==3.5.9
 django-cors-headers==2.4.0
-django-debug-toolbar==1.9.1
+django-debug-toolbar==1.10.1
 django-ums-client==0.2.6
 django-webpack-loader==0.6.0
 djangorestframework==3.8.2
 flake8==3.5.0
 flake8-quotes==1.0.0
 idna==2.7
-lxml==4.2.4
+lxml==4.2.5
 mccabe==0.6.1
 mock==2.0.0
 pbr==4.2.0

--- a/app/gather/assets/css/base/_fonts.scss
+++ b/app/gather/assets/css/base/_fonts.scss
@@ -25,7 +25,7 @@
 
 /* Font Awesome 5 */
 /* https://fontawesome.com/get-started/web-fonts-with-css */
-@import url('https://use.fontawesome.com/releases/v5.2.0/css/solid.css');
-@import url('https://use.fontawesome.com/releases/v5.2.0/css/fontawesome.css');
+@import url('https://use.fontawesome.com/releases/v5.3.1/css/solid.css');
+@import url('https://use.fontawesome.com/releases/v5.3.1/css/fontawesome.css');
 
 // sass-lint:enable no-url-domains no-url-protocols

--- a/app/gather/assets/package.json
+++ b/app/gather/assets/package.json
@@ -26,11 +26,11 @@
     "jquery": "~3.3.0",
     "moment": "~2.22.0",
     "popper.js": "~1.14.0",
-    "react": "~16.4.0",
-    "react-dom": "~16.4.0",
+    "react": "~16.5.0",
+    "react-dom": "~16.5.0",
     "react-filtered-multiselect": "~0.5.0",
     "react-intl": "~2.4.0",
-    "whatwg-fetch": "~2.0.0"
+    "whatwg-fetch": "~3.0.0"
   },
 
   "devDependencies": {
@@ -41,9 +41,9 @@
     "babel-loader": "~8.0.0",
     "css-loader": "~1.0.0",
     "enzyme": "~3.6.0",
-    "enzyme-adapter-react-16": "~1.4.0",
+    "enzyme-adapter-react-16": "~1.5.0",
     "enzyme-react-intl": "~2.0.0",
-    "jest": "~23.5.0",
+    "jest": "~23.6.0",
     "mini-css-extract-plugin": "~0.4.0",
     "nock": "~9.6.0",
     "node-fetch": "~2.2.0",
@@ -53,7 +53,7 @@
     "sass-loader": "~7.1.0",
     "standard": "~12.0.0",
     "style-loader": "~0.23.0",
-    "webpack": "~4.17.0",
+    "webpack": "~4.18.0",
     "webpack-bundle-tracker": "~0.3.0",
     "webpack-cli": "~3.1.0",
     "webpack-dev-server": "~3.1.0"


### PR DESCRIPTION
Notice that `whatwg-fetch@3.0.0` finally accepts the `AbortSignal` option, that allows us to release pending requests when the components are unmounted.

https://github.com/github/fetch/releases/tag/v3.0.0