### PR TITLE
fix: endpoint renamed to propagate

### DIFF
--- a/app/gather/assets/apps/survey/SurveyForm.jsx
+++ b/app/gather/assets/apps/survey/SurveyForm.jsx
@@ -537,7 +537,7 @@ class SurveyForm extends Component {
     actions.push({
       message: formatMessage(MESSAGES.propagateODKSurvey, { name: this.state.name }),
       method: patchData,
-      url: getSurveysAPIPath({ app: ODK_APP, id: this.state.id, action: 'propagates' })
+      url: getSurveysAPIPath({ app: ODK_APP, id: this.state.id, action: 'propagate' })
     })
 
     const executeActions = () => {

--- a/app/gather/assets/apps/utils/paths.jsx
+++ b/app/gather/assets/apps/utils/paths.jsx
@@ -123,7 +123,7 @@ export const getMasksAPIPath = ({ id, ...params }) => {
 const buildAPIPath = (app, type, id, { format = 'json', action, ...params }) => {
   const suffix = (
     (id ? '/' + id : '') +
-    // indicates the ation suffix like "details", "fetch" or "propagates"
+    // indicates the ation suffix like "details", "fetch" or "propagate"
     (action ? '/' + action : ''))
   const url = `${API_PREFIX}/${app}/${type}${suffix}.${format}`
   const queryString = id ? '' : buildQueryString(params)


### PR DESCRIPTION
In the last releases we renamed the `propagates` endpoint to `propagate`