### PR TITLE
fix: sync endpoint is mobile-users

### DIFF
--- a/app/gather/assets/apps/utils/paths.jsx
+++ b/app/gather/assets/apps/utils/paths.jsx
@@ -51,13 +51,13 @@ export const getSurveyorsAPIPath = ({ id, ...params }) => {
 }
 
 /**
- * Returns the API url to get the Sync Users data
+ * Returns the API url to get the Sync/Mobile Users data
  *
  * @param {number}  id          - sync user id
  * @param {object}  params      - query string parameters
  */
 export const getSyncUsersAPIPath = ({ id, ...params }) => {
-  return buildAPIPath(COUCHDB_SYNC_APP, 'sync-users', id, params)
+  return buildAPIPath(COUCHDB_SYNC_APP, 'mobile-users', id, params)
 }
 
 /**

--- a/app/gather/assets/apps/utils/paths.spec.jsx
+++ b/app/gather/assets/apps/utils/paths.spec.jsx
@@ -54,8 +54,8 @@ describe('paths utils', () => {
 
   describe('getSyncUsersAPIPath', () => {
     it('should return the Sync Users API path', () => {
-      assert.strictEqual(getSyncUsersAPIPath({ }), '/couchdb-sync/sync-users.json')
-      assert.strictEqual(getSyncUsersAPIPath({ id: 1 }), '/couchdb-sync/sync-users/1.json')
+      assert.strictEqual(getSyncUsersAPIPath({ }), '/couchdb-sync/mobile-users.json')
+      assert.strictEqual(getSyncUsersAPIPath({ id: 1 }), '/couchdb-sync/mobile-users/1.json')
     })
   })
 


### PR DESCRIPTION
This happens when you rename everything without control! :scream: :disappointed: 

Another solution to make this more coherence is to create the alias in the aether module

```python
router.register('mobile-users', views.MobileUserViewSet)
router.register('sync-users', views.MobileUserViewSet)
```

What do you prefer?
