### PR TITLE
feat: only fetch passthrough items from kernel

### DIFF
--- a/app/gather/assets/apps/utils/paths.jsx
+++ b/app/gather/assets/apps/utils/paths.jsx
@@ -35,9 +35,9 @@ const APPS = [ KERNEL_APP, ODK_APP, COUCHDB_SYNC_APP, GATHER_APP ]
  */
 export const getSurveysAPIPath = ({ app, id, withStats, ...params }) => {
   const source = (APPS.indexOf(app) === -1 ? KERNEL_APP : app)
-  const stats = (source === KERNEL_APP && withStats ? '-stats' : '')
+  const suffix = (source === KERNEL_APP && withStats ? '-stats' : '')
 
-  return buildAPIPath(source, `projects${stats}`, id, { ...params })
+  return buildAPIPath(source, `projects${suffix}`, id, params)
 }
 
 /**
@@ -127,7 +127,13 @@ const buildAPIPath = (app, type, id, { format = 'json', action, ...params }) => 
     (action ? '/' + action : ''))
   const formatSuffix = (format === '' ? '/' : '.' + format)
   const url = `${API_PREFIX}/${app}/${type}${suffix}${formatSuffix}`
-  const queryString = id ? '' : buildQueryString(params)
+
+  // any call that goes to kernel must include the `passthrough` filter
+  const queryParams = {
+    ...(app === KERNEL_APP ? { passthrough: 'true' } : {}),
+    ...(id ? {} : params)
+  }
+  const queryString = buildQueryString(queryParams)
 
   return queryString === '' ? url : `${url}?${queryString}`
 }

--- a/app/gather/assets/apps/utils/paths.spec.jsx
+++ b/app/gather/assets/apps/utils/paths.spec.jsx
@@ -63,31 +63,42 @@ describe('paths utils', () => {
     describe('without app or `kernel` app', () => {
       const prefix = '/kernel/'
 
+      // NOTE: the `passthrough` parameter is ALWAYS include,
+      // this does not apply to rest of parameters
+
       it('should return the Surveys API path', () => {
-        assert.strictEqual(getSurveysAPIPath({}), prefix + 'projects.json')
-        assert.strictEqual(getSurveysAPIPath({ id: 1 }), prefix + 'projects/1.json')
+        assert.strictEqual(getSurveysAPIPath({}), prefix + 'projects.json?passthrough=true')
+        assert.strictEqual(getSurveysAPIPath({ id: 1 }), prefix + 'projects/1.json?passthrough=true')
       })
 
       it('should return the Surveys Stats API path', () => {
-        assert.strictEqual(getSurveysAPIPath({ app: 'kernel', withStats: true }), prefix + 'projects-stats.json')
-        assert.strictEqual(getSurveysAPIPath({ withStats: true, id: 1 }), prefix + 'projects-stats/1.json')
+        assert.strictEqual(
+          getSurveysAPIPath({ app: 'kernel', withStats: true }),
+          prefix + 'projects-stats.json?passthrough=true')
+        assert.strictEqual(
+          getSurveysAPIPath({ withStats: true, id: 1 }),
+          prefix + 'projects-stats/1.json?passthrough=true')
       })
 
       it('should return the Surveys API path with search', () => {
-        assert.strictEqual(getSurveysAPIPath({ search: 'survey' }), prefix + 'projects.json?search=survey')
+        assert.strictEqual(
+          getSurveysAPIPath({ search: 'survey' }),
+          prefix + 'projects.json?passthrough=true&search=survey')
       })
 
       it('should return the Surveys API path without search', () => {
-        assert.strictEqual(getSurveysAPIPath({ app: 'kernel', search: 'survey', id: 1 }), prefix + 'projects/1.json')
+        assert.strictEqual(
+          getSurveysAPIPath({ search: 'survey', id: 1 }),
+          prefix + 'projects/1.json?passthrough=true')
       })
 
       it('should return the Surveys API path with the POST option', () => {
         assert.strictEqual(
           getSurveysAPIPath({ app: 'kernel', format: 'txt', action: 'fetch' }),
-          prefix + 'projects/fetch.txt')
+          prefix + 'projects/fetch.txt?passthrough=true')
         assert.strictEqual(
           getSurveysAPIPath({ app: 'kernel', format: 'txt', action: 'details', id: 1 }),
-          prefix + 'projects/1/details.txt')
+          prefix + 'projects/1/details.txt?passthrough=true')
       })
     })
 
@@ -126,12 +137,29 @@ describe('paths utils', () => {
   describe('getEntitiesAPIPath', () => {
     const prefix = '/kernel/'
 
+    // NOTE: the `passthrough` parameter is ALWAYS include,
+    // this does not apply to rest of parameters
+
     it('should return the Entities API path', () => {
-      assert.strictEqual(getEntitiesAPIPath({}), prefix + 'entities.json')
+      assert.strictEqual(getEntitiesAPIPath({}), prefix + 'entities.json?passthrough=true')
     })
 
     it('should return the Survey Entities API path', () => {
-      assert.strictEqual(getEntitiesAPIPath({ project: 1 }), prefix + 'entities.json?project=1')
+      assert.strictEqual(
+        getEntitiesAPIPath({ project: 1 }),
+        prefix + 'entities.json?passthrough=true&project=1')
+    })
+
+    it('should return the Surveys Entities API path with search', () => {
+      assert.strictEqual(
+        getEntitiesAPIPath({ search: 'survey' }),
+        prefix + 'entities.json?passthrough=true&search=survey')
+    })
+
+    it('should return the Surveys Entities API path without search', () => {
+      assert.strictEqual(
+        getEntitiesAPIPath({ search: 'survey', id: 1 }),
+        prefix + 'entities/1.json?passthrough=true')
     })
   })
 

--- a/app/gather/assets/apps/utils/paths.spec.jsx
+++ b/app/gather/assets/apps/utils/paths.spec.jsx
@@ -63,7 +63,7 @@ describe('paths utils', () => {
     describe('without app or `kernel` app', () => {
       const prefix = '/kernel/'
 
-      // NOTE: the `passthrough` parameter is ALWAYS include,
+      // NOTE: the `passthrough` parameter is ALWAYS included,
       // this does not apply to rest of parameters
 
       it('should return the Surveys API path', () => {
@@ -137,7 +137,7 @@ describe('paths utils', () => {
   describe('getEntitiesAPIPath', () => {
     const prefix = '/kernel/'
 
-    // NOTE: the `passthrough` parameter is ALWAYS include,
+    // NOTE: the `passthrough` parameter is ALWAYS included,
     // this does not apply to rest of parameters
 
     it('should return the Entities API path', () => {


### PR DESCRIPTION
Pending on new aether release, in the meantime use the aether `alpha` release or aether `develop` branch.

Closes: https://jira.ehealthafrica.org/browse/AET-351

Instead of marking somehow all the schemas created using Gather this PR assumes that all the passthrough schemas were created using Gather and the rest of them using UI or manually. So there is no field to save in Gather, no list of schemas, xforms...

Just a quick and simple solution.

To test it just create a project in gather with one xform and create a couple of submissions for it. Everything appears as usual in Gather.

Go to Kernel and change the `family` field in the auto-generated schema. Go back to Gather, all the entities must have disappeared. Save the project in Gather (no changes required). The save method will change the `family` field to its original value and the entities will show up again.

You can also create a different schema+entities, those entities should not appear in Gather (neither in the project stats).

To see your previous project entities just save the older projects again :wink:
