### PR TITLE
Fix styling repeat groups

### DIFF
--- a/app/gather/assets/css/_survey-view.scss
+++ b/app/gather/assets/css/_survey-view.scss
@@ -147,10 +147,6 @@
       margin-left: -1.8rem;
       margin-right: .4rem;
     }
-
-    .property:first-child {
-      padding-top: 0;
-    }
   }
 
   .property:last-child {
@@ -167,7 +163,7 @@
     flex: 1;
     color: $dark-grey;
     margin: 0;
-    margin-right: 1rem;
+    margin-right: 1.6rem;
   }
 
   .property-value {
@@ -199,10 +195,6 @@
       margin: 1rem;
       margin-left: calc(-33.3% - 2rem);
       margin-right: -1rem;
-    }
-
-    .data {
-      padding-top: .5rem;
     }
   }
 
@@ -279,13 +271,21 @@
     }
   }
 
-  .data > .property-list {
-    min-width: 50vw;
+  .property-list {
+    min-width: 30rem;
   }
 
   .property-list {
     padding: 0;
     list-style-position: inside;
+  }
+
+  .property-item {
+    margin: .3rem 0 0 1.6rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   .property {
@@ -307,6 +307,7 @@
     flex: 1;
     color: $dark-grey;
     margin-right: 1rem;
+    min-width: 12rem;
   }
 
   .property-value {
@@ -314,7 +315,11 @@
   }
 
   .badge {
-    margin-left: .5rem;
+    margin-left: 1.5rem;
+  }
+
+  .btn {
+    position: absolute;
   }
 }
 

--- a/app/gather/assets/css/base/_global.scss
+++ b/app/gather/assets/css/base/_global.scss
@@ -67,6 +67,7 @@ button {
   &:focus,
   &:hover {
     background-color: $hover-color;
+    color: $white;
   }
 }
 
@@ -216,8 +217,9 @@ small {
 .badge {
   background: $grey;
   border-radius: 1rem;
-  padding: .3rem .6rem;
+  padding: .1rem .5rem;
   font-size: $font-size-s;
+  line-height: 1.2em;
 
   .icon-only {
     margin-right: -.3rem;

--- a/app/gather/assets/css/base/_pagination.scss
+++ b/app/gather/assets/css/base/_pagination.scss
@@ -30,6 +30,7 @@
   font-weight: 500;
   margin: 0;
   padding: .3rem 5vw;
+  min-height: 2rem;
   box-shadow: 0 1px 2px rgba($text-color, .5);
 
   .pagination {
@@ -37,16 +38,12 @@
     border-radius: 0;
     display: flex;
     align-items: baseline;
-    padding-left: .75rem;
+    padding: 0 .5rem;
     border-left: 1px solid $white;
 
     li {
       display: inline;
-      margin: 0 .3rem;
-    }
-
-    li:last-child {
-      margin-right: 0;
+      margin: 0 .5rem;
     }
   }
 
@@ -92,6 +89,7 @@
     text-decoration: none;
     text-transform: uppercase;
     padding: .3rem .75rem;
+    margin: 0 -.3rem;
 
     &:hover {
       color: $action-color;
@@ -122,16 +120,17 @@
       color: $white;
       font-family: $body-font-family;
       font-size: $font-size-standard;
-      padding: .3rem 1rem .3rem 1.8rem;
+      padding: .3rem 1rem .3rem 2rem;
       margin: .2rem 0;
       background: none;
       z-index: 2;
       transition: width .5s;
+      width: 120px;
 
       &:focus,
       &:hover,
       &.value {
-        width: 150px;
+        width: 250px;
         background: rgba($white, .1);
       }
 


### PR DESCRIPTION
fixed small issues regarding the display of repeat groups in tables and single view.
The columns within repeat groups in a table now have wider columns.
partly fixes https://jira.ehealthafrica.org/browse/GTH-129
The ordering issue is still there, even though it was mentioned to be fixed.
![Bildschirmfoto 2019-04-02 um 13 58 38](https://user-images.githubusercontent.com/5364805/55400985-aa553900-554f-11e9-9bc4-a12c49d11001.png)

