### PR TITLE
chore: upgrade to postgres-client-10

### DIFF
--- a/app/conf/docker/setup.sh
+++ b/app/conf/docker/setup.sh
@@ -20,7 +20,7 @@
 #
 set -Eeuo pipefail
 
-POSTGRES_PACKAGE=postgresql-client-9.6
+POSTGRES_PACKAGE=postgresql-client-10
 APT_INSTALL="apt-get -qq --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install"
 
 ################################################################################

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -7,7 +7,7 @@ services:
   # ---------------------------------
 
   postgres-base:
-    image: postgres:9.6-alpine
+    image: postgres:10-alpine
     environment:
       PGUSER: postgres
     healthcheck:


### PR DESCRIPTION
This PR only upgrades the postgres client in the gather container, this doesn't affect the deployments or the behavior in any server.

The client is used only to create, restore and backup the database. It is unlikely to use those commands  in any server, we use them locally to speed up our set up.
