### PR TITLE
fix: ordering of repeat group fields in table view (#105)

### DIFF
--- a/app/gather/assets/apps/components/FetchUrlsContainer.jsx
+++ b/app/gather/assets/apps/components/FetchUrlsContainer.jsx
@@ -49,7 +49,7 @@ import RefreshSpinner from './RefreshSpinner'
  *                         (loading, error) are hidden.
  *                         The whole fetch process is in silent mode.
  *
- *   `handleResponse`:     Function that transform the response.
+ *   `handleResponse`:     Function that transforms the response.
  *
  *   `targetComponent`:    The rendered component after a sucessful request.
  *                         It's going to received as properties the trasformed

--- a/app/gather/assets/apps/components/PaginationContainer.jsx
+++ b/app/gather/assets/apps/components/PaginationContainer.jsx
@@ -52,6 +52,7 @@ import RefreshSpinner from './RefreshSpinner'
  *   `showXxx`:           Indicates if the button `Xxx` (`First` , `Previous`, `Next`, `Last`)
  *                        is shown in the pagination bar.
  *   `extras`:            An object that passes directly to the listComponent.
+ *   `mapResponse`:       Function that maps the list of results.
  *
  */
 
@@ -137,9 +138,11 @@ class PaginationContainer extends Component {
       return <FetchErrorAlert error={this.state.error} />
     }
 
+    const { mapResponse } = this.props
     const position = this.props.position || 'bottom'
     const { count, results } = this.state.list
     const ListComponent = this.props.listComponent
+    const list = mapResponse ? mapResponse(results) : results
 
     return (
       <div data-qa='data-loaded'>
@@ -152,7 +155,7 @@ class PaginationContainer extends Component {
         { count > 0 &&
           <ListComponent
             {...this.props.extras}
-            list={results}
+            list={list}
             total={count}
             start={this.state.pageSize * (this.state.page - 1) + 1}
           />

--- a/app/gather/assets/apps/components/PaginationContainer.spec.jsx
+++ b/app/gather/assets/apps/components/PaginationContainer.spec.jsx
@@ -35,7 +35,7 @@ import {
 
 class Foo extends React.Component {
   render () {
-    return 'foo'
+    return `foo: [${this.props.list}]`
   }
 }
 
@@ -175,7 +175,7 @@ describe('PaginationContainer', () => {
       expect(component.find(PaginationBar).exists()).toBeTruthy()
       expect(component.find(EmptyAlert).exists()).toBeFalsy()
       expect(component.find(Foo).exists()).toBeTruthy()
-      expect(component.text()).toEqual('foo')
+      expect(component.text()).toEqual('foo: [1]')
     })
 
     it('should render the list component', () => {
@@ -184,8 +184,8 @@ describe('PaginationContainer', () => {
       component.setState({
         ...BLANK_STATE,
         list: {
-          count: 1,
-          results: [1]
+          count: 2,
+          results: [1, 2]
         }
       })
 
@@ -196,7 +196,7 @@ describe('PaginationContainer', () => {
       expect(component.find(PaginationBar).exists()).toBeTruthy()
       expect(component.find(EmptyAlert).exists()).toBeFalsy()
       expect(component.find(Foo).exists()).toBeTruthy()
-      expect(component.text()).toEqual('foo')
+      expect(component.text()).toEqual('foo: [1,2]')
     })
 
     it('should change current page to 1 if pageSize is changed', () => {
@@ -252,6 +252,7 @@ describe('PaginationContainer', () => {
           listComponent={Foo}
           url={url + '?'}
           position='top'
+          mapResponse={(list) => list.map(a => a + 1)}
         />
       )
 
@@ -344,7 +345,7 @@ describe('PaginationContainer', () => {
       expect(component.find(PaginationBar).exists()).toBeTruthy()
       expect(component.find(EmptyAlert).exists()).toBeFalsy()
       expect(component.find(Foo).exists()).toBeTruthy()
-      expect(component.text()).toEqual('foo')
+      expect(component.text()).toEqual('foo: [2]')
     })
   })
 

--- a/app/gather/assets/apps/survey/entity/EntityItem.jsx
+++ b/app/gather/assets/apps/survey/entity/EntityItem.jsx
@@ -33,7 +33,6 @@ export default class EntityItem extends Component {
       return <div />
     }
 
-    // assumption: there is only one item
     const entity = list[0]
     const attachments = attachmentsToLinks(entity.attachments)
 

--- a/app/gather/assets/apps/utils/types.spec.jsx
+++ b/app/gather/assets/apps/utils/types.spec.jsx
@@ -29,7 +29,8 @@ import {
   getLabelTree,
   getType,
   inflate,
-  unflatten
+  unflatten,
+  reorderObjectKeys
 } from './types'
 
 describe('types', () => {
@@ -149,7 +150,7 @@ describe('types', () => {
       assert.deepStrictEqual(unflatten(entry), expected)
     })
 
-    it('should not unflatten array properties', () => {
+    it('should not unflatten array properties (in values)', () => {
       const entry = { 'a:b:c:d': 1, 'a:b:a': [1, 2, {}, { d: 1 }] }
       const expected = {
         a: {
@@ -164,6 +165,46 @@ describe('types', () => {
 
       assert.deepStrictEqual(unflatten(entry, ':'), expected)
     })
+
+    it('should not unflatten array properties (in keys)', () => {
+      const entry = { 'a;b;0;d': 1, 'a;b;1': 1 }
+      const expected = {
+        a: {
+          b: {
+            0: {
+              d: 1
+            },
+            1: 1
+          }
+        }
+      }
+
+      assert.deepStrictEqual(unflatten(entry, ';'), expected)
+    })
+  })
+
+  describe('flatten & unflatten', () => {
+    it('should be idempotent (flatten+unflatten)', () => {
+      const entry = {
+        'a:b:c:d': 1,
+        'a:b:a': [1, 2, {}, { d: 1 }]
+      }
+      assert.deepStrictEqual(flatten(unflatten(entry, ':'), ':'), entry)
+    })
+
+    it('should be idempotent (unflatten+flatten)', () => {
+      const entry = {
+        a: {
+          b: {
+            c: {
+              d: 1
+            },
+            a: [1, 2, {}, { d: 1 }]
+          }
+        }
+      }
+      assert.deepStrictEqual(unflatten(flatten(entry)), entry)
+    })
   })
 
   describe('inflate', () => {
@@ -171,7 +212,36 @@ describe('types', () => {
       assert.deepStrictEqual(inflate([]), [])
     })
 
-    it('should analyze flat JSON objects', () => {
+    it('should analyze flat JSON objects with `.` separator', () => {
+      const keys = [
+        'a.b.c',
+        'a.b.d',
+        'a.e.f',
+        'a.g',
+        'h'
+      ]
+
+      const expectedValue = [
+        {
+          a: { key: 'a', path: 'a', siblings: 4, hasChildren: true, isLeaf: false },
+          h: { key: 'h', path: 'h', siblings: 1, hasChildren: false, isLeaf: true }
+        },
+        {
+          'a.b': { key: 'a.b', path: 'a.b', siblings: 2, hasChildren: true, isLeaf: false },
+          'a.e': { key: 'a.e', path: 'a.e', siblings: 1, hasChildren: true, isLeaf: false },
+          'a.g': { key: 'a.g', path: 'a.g', siblings: 1, hasChildren: false, isLeaf: true }
+        },
+        {
+          'a.b.c': { key: 'a.b.c', path: 'a.b.c', siblings: 1, hasChildren: false, isLeaf: true },
+          'a.b.d': { key: 'a.b.d', path: 'a.b.d', siblings: 1, hasChildren: false, isLeaf: true },
+          'a.e.f': { key: 'a.e.f', path: 'a.e.f', siblings: 1, hasChildren: false, isLeaf: true }
+        }
+      ]
+
+      assert.deepStrictEqual(inflate(keys), expectedValue)
+    })
+
+    it('should analyze flat JSON objects with custom separator', () => {
       const keys = [
         'a|b|c',
         'a|b|d',
@@ -212,19 +282,31 @@ describe('types', () => {
         a: {
           b: {
             c: {
-              d: 1
-            }
-          }
-        }
+              d: 1,
+              dd: 2
+            },
+            cc: 2
+          },
+          bb: 2
+        },
+        aa: 2
       }
 
       assert.deepStrictEqual(flatten(filterByPaths(entry, [])), {})
       assert.deepStrictEqual(flatten(filterByPaths(entry, ['b'])), {})
 
-      assert.deepStrictEqual(flatten(filterByPaths(entry, ['a.b.c.d'])), { 'a.b.c.d': 1 })
-      assert.deepStrictEqual(flatten(filterByPaths(entry, ['a.b.c'])), { 'a.b.c.d': 1 })
-      assert.deepStrictEqual(flatten(filterByPaths(entry, ['a.b'])), { 'a.b.c.d': 1 })
-      assert.deepStrictEqual(flatten(filterByPaths(entry, ['a'])), { 'a.b.c.d': 1 })
+      assert.deepStrictEqual(
+        flatten(filterByPaths(entry, ['a.b.c.d'])),
+        { 'a.b.c.d': 1 })
+      assert.deepStrictEqual(
+        flatten(filterByPaths(entry, ['a.b.c'])),
+        { 'a.b.c.d': 1, 'a.b.c.dd': 2 })
+      assert.deepStrictEqual(
+        flatten(filterByPaths(entry, ['a.b'])),
+        { 'a.b.c.d': 1, 'a.b.c.dd': 2, 'a.b.cc': 2 })
+      assert.deepStrictEqual(
+        flatten(filterByPaths(entry, ['a'])),
+        { 'a.b.c.d': 1, 'a.b.c.dd': 2, 'a.b.cc': 2, 'a.bb': 2 })
     })
   })
 
@@ -278,8 +360,17 @@ describe('types', () => {
       assert.strictEqual(getLabelTree('a.b.c.d.e'), 'a / b / c / d / e')
       assert.strictEqual(getLabelTree('a.b.c.d.e', labels), 'Root / b / The Big C / d / e')
 
-      assert.strictEqual(getLabelTree('a:b:c:d:e', {}, ':', '$'), 'a$b$c$d$e')
-      assert.strictEqual(getLabelTree('a.b.c.d.e', labels, '.', '$'), 'Root$b$The Big C$d$e')
+      assert.strictEqual(getLabelTree('a.b.c.d.e', labels, '$'), 'Root$b$The Big C$d$e')
+
+      const labels2 = {
+        a: 'Root',
+        'a:d:#:e': 'The indexed E',
+        'a:*:c': 'The Big C',
+        'a:*:c:?:u': 'Join',
+        'x:y:?:z': 'Union'
+      }
+      assert.strictEqual(getLabelTree('a:b:c:d:e', {}, '$', ':'), 'a$b$c$d$e')
+      assert.strictEqual(getLabelTree('a:b:c:d:e', labels2, '-', ':'), 'Root-b-The Big C-d-e')
     })
   })
 
@@ -310,6 +401,223 @@ describe('types', () => {
       ]
 
       assert.deepStrictEqual(cleanJsonPaths(paths), expected)
+    })
+  })
+
+  describe('reorderObjectKeys', () => {
+    describe('should preserve object values but not keys order', () => {
+      it('with simple paths', () => {
+        const entry = {
+          b: 1,
+          c: 2,
+          a: {
+            b: 1,
+            a: 0
+          }
+        }
+        const paths = [
+          'a',
+          'a.a',
+          'a.b',
+          'c',
+          'b'
+        ]
+
+        const oEntry = reorderObjectKeys(entry, paths)
+        assert.deepStrictEqual(oEntry, entry) // it's the same object
+
+        // but `Object.keys` returns different values in each case
+        assert.deepStrictEqual(Object.keys(flatten(entry)), ['b', 'c', 'a.b', 'a.a'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry)), ['a.a', 'a.b', 'c', 'b'])
+      })
+
+      it('with ARRAY paths', () => {
+        const entry = {
+          // array of primitives
+          i: [0, 1, 2],
+          // array of objects
+          l: [
+            { z: 3, x: 1, y: 2 },
+            { z: 3, y: 2, x: 1 },
+            { x: 1, z: 3, y: 2 }
+          ],
+          // array of array of objects
+          m: [[{ b: 1, a: 0 }]],
+          // nested arrays
+          n: [
+            { a: 1 },
+            {
+              b: [
+                { d: [0], c: 1 },
+                { d: [], c: 2 },
+                { c: 3 }
+              ],
+              a: 1
+            }
+          ],
+          // array of array of primitives
+          k: [[0], [1], [2]]
+        }
+        const paths = [
+          'l',
+          'l.#',
+          'l.#.x',
+          'l.#.y',
+          'l.#.z',
+          'i',
+          'i.#',
+          'k',
+          'k.#',
+          'k.#.#',
+          'n',
+          'n.#',
+          'n.#.a',
+          'n.#.b',
+          'n.#.b.#',
+          'n.#.b.#.c',
+          'n.#.b.#.d',
+          'n.#.b.#.d.#',
+          'm',
+          'm.#',
+          'm.#.#',
+          'm.#.#.a',
+          'm.#.#.b'
+        ]
+
+        const oEntry = reorderObjectKeys(entry, paths)
+        assert.deepStrictEqual(oEntry, entry) // it's the same object
+
+        // but `Object.keys` returns different values in each case
+        assert.deepStrictEqual(Object.keys(flatten(entry)), ['i', 'l', 'm', 'n', 'k'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry)), ['l', 'i', 'k', 'n', 'm'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.l[0])), ['z', 'x', 'y'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.l[0])), ['x', 'y', 'z'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.l[1])), ['z', 'y', 'x'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.l[1])), ['x', 'y', 'z'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.l[2])), ['x', 'z', 'y'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.l[2])), ['x', 'y', 'z'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.n[1])), ['b', 'a'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.n[1])), ['a', 'b'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.n[1].b[0])), ['d', 'c'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.n[1].b[0])), ['c', 'd'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.m[0][0])), ['b', 'a'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.m[0][0])), ['a', 'b'])
+      })
+
+      it('with UNION paths', () => {
+        const paths = [
+          'u',
+          'u.?',
+          'u.?.x',
+          'u.?.y',
+          'u.?.z',
+          'w',
+          'w.?',
+          'w.?.#',
+          'w.?.a'
+        ]
+
+        const entry1 = {
+          w: [],
+          u: { y: 2, x: 1 }
+        }
+        const oEntry1 = reorderObjectKeys(entry1, paths)
+        assert.deepStrictEqual(oEntry1, entry1) // it's the same object
+
+        // but `Object.keys` returns different values in each case
+        assert.deepStrictEqual(Object.keys(flatten(entry1)), ['w', 'u.y', 'u.x'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry1)), ['u.x', 'u.y', 'w'])
+
+        const entry2 = {
+          w: { a: 1 },
+          u: { y: 2, x: 1 }
+        }
+
+        const oEntry2 = reorderObjectKeys(entry2, paths)
+        assert.deepStrictEqual(oEntry2, entry2) // it's the same object
+
+        // but `Object.keys` returns different values in each case
+        assert.deepStrictEqual(Object.keys(flatten(entry2)), ['w.a', 'u.y', 'u.x'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry2)), ['u.x', 'u.y', 'w.a'])
+      })
+
+      it('with MAP paths', () => {
+        const entry = {
+          // map of objects
+          r: {
+            // the root keys are not going to be ordered,
+            // but the nested ones yes
+            c: { b: 1, a: 2 },
+            b: { b: 1, a: 2 },
+            a: { b: 1, a: 2 }
+          },
+          // map of primitives
+          s: {
+            z: 0,
+            y: 1,
+            x: 2
+          },
+          // array inside map
+          t: { x: [{ a: 1, b: 1, c: 1 }] },
+          // map inside array
+          w: [{ x: { a: 1, b: 1, c: 1 } }]
+        }
+        const paths = [
+          'r',
+          'r.*',
+          'r.*.a',
+          'r.*.b',
+          's',
+          's.*',
+          't',
+          't.*',
+          't.*.#',
+          't.*.#.c',
+          't.*.#.a',
+          't.*.#.b',
+          'w',
+          'w.#',
+          'w.#.*',
+          'w.#.*.c',
+          'w.#.*.b',
+          'w.#.*.a'
+        ]
+
+        const oEntry = reorderObjectKeys(entry, paths)
+        assert.deepStrictEqual(oEntry, entry) // it's the same object
+
+        // but `Object.keys` returns different values in each case
+        assert.deepStrictEqual(
+          Object.keys(flatten(entry)),
+          [
+            'r.c.b', 'r.c.a',
+            'r.b.b', 'r.b.a',
+            'r.a.b', 'r.a.a',
+            's.z', 's.y', 's.x',
+            't.x', 'w'
+          ])
+        assert.deepStrictEqual(
+          Object.keys(flatten(oEntry)),
+          [
+            'r.c.a', 'r.c.b',
+            'r.b.a', 'r.b.b',
+            'r.a.a', 'r.a.b',
+            's.z', 's.y', 's.x',
+            't.x', 'w'
+          ])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.t.x[0])), ['a', 'b', 'c'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.t.x[0])), ['c', 'a', 'b'])
+
+        assert.deepStrictEqual(Object.keys(flatten(entry.w[0].x)), ['a', 'b', 'c'])
+        assert.deepStrictEqual(Object.keys(flatten(oEntry.w[0].x)), ['c', 'b', 'a'])
+      })
     })
   })
 })


### PR DESCRIPTION
* docs: proper English

* feat(assets): PaginationContainer with mapResponse

* test(assets): more flatten&unflatten tests

* docs: remove useless comment

* feat: implement [reorderObjectKeys] method
