### PR TITLE
fix: no attachments without submission

### DIFF
--- a/app/gather/assets/apps/survey/entity/utils.jsx
+++ b/app/gather/assets/apps/survey/entity/utils.jsx
@@ -21,7 +21,7 @@
 import { getAttachmentContentPath } from '../../utils/paths'
 
 export const attachmentsToLinks = (attachments) => (
-  attachments.map(({ id, name }) => ({
+  (attachments || []).map(({ id, name }) => ({
     name,
     url: id ? getAttachmentContentPath({ id }) : '#'
   }))

--- a/app/gather/assets/apps/survey/entity/utils.spec.jsx
+++ b/app/gather/assets/apps/survey/entity/utils.spec.jsx
@@ -26,6 +26,7 @@ import { attachmentsToLinks } from './utils'
 describe('Entity utils', () => {
   describe('parseAttachments', () => {
     it('should return the list of attachments with the name and URL', () => {
+      assert.deepStrictEqual(attachmentsToLinks(), [])
       assert.deepStrictEqual(attachmentsToLinks([]), [])
       assert.deepStrictEqual(
         attachmentsToLinks([


### PR DESCRIPTION
If the entity is not linked to any submission the `attachments` property is undefined. That made the page crash.

That was the issue in the MC server.