### PR TITLE
fix: ODK does not require 8443 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This will start:
 
 - **gather** on `http://gather.local/`.
 - **aether-kernel** on `http://aether.local/kernel/`.
-- **aether-odk** on `http://aether.local/odk/` or `http://aether.local:8443/odk/`.
+- **aether-odk** on `http://aether.local/odk/`.
 - **aether-ui** on `http://aether.local/`.
 
 All the created superusers have username `${ADMIN_USERNAME}` and

--- a/app/gather/context_processors.py
+++ b/app/gather/context_processors.py
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from urllib.parse import urlparse
-
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
@@ -52,13 +50,5 @@ def gather_context(request):
         name = app.replace('-', '_')
         external_app = f'{settings.AETHER_PREFIX}{app}'
         context[f'{name}_url'] = get_external_app_url(external_app, request)
-
-    if 'odk' in settings.AETHER_APPS:
-        # ODK Collect requires or protocol https or port 8443
-        # check the current aether-odk URL and adapt it
-        # to these specific requirements
-        url_info = urlparse(context['odk_url'])
-        if url_info.scheme != 'https' and url_info.port != 8443:
-            context['odk_url'] = f'http://{url_info.hostname}:8443{url_info.path}'
 
     return context

--- a/app/gather/tests/test_context_processors.py
+++ b/app/gather/tests/test_context_processors.py
@@ -16,9 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from unittest import mock
-
-from django.conf import settings
 from django.test import RequestFactory, override_settings
 from aether.sdk.unittest import UrlsTestCase
 
@@ -42,9 +39,10 @@ class ContextProcessorsTests(UrlsTestCase):
         self.assertIn('odk_url', context)
         self.assertIn('couchdb_sync_url', context)
 
-    @mock.patch('gather.context_processors.settings.AETHER_APPS', ['kernel'])
-    @mock.patch('gather.context_processors.settings.EXTERNAL_APPS',
-                {'aether-kernel': {'test': {'url': 'http://localhost'}}})
+    @override_settings(
+        AETHER_APPS=['kernel'],
+        EXTERNAL_APPS={'aether-kernel': {'test': {'url': 'http://localhost'}}},
+    )
     def test_gather_context__mocked(self):
         request = RequestFactory().get('/')
         context = gather_context(request)
@@ -55,26 +53,6 @@ class ContextProcessorsTests(UrlsTestCase):
         self.assertIn('kernel_url', context)
         self.assertNotIn('odk_url', context)
         self.assertNotIn('couchdb_sync_url', context)
-
-    @mock.patch('gather.context_processors.settings.EXTERNAL_APPS',
-                {
-                    **settings.EXTERNAL_APPS,
-                    'aether-odk': {'test': {'url': 'https://localhost'}},
-                })
-    def test_gather_context__odk__https(self):
-        request = RequestFactory().get('/')
-        context = gather_context(request)
-        self.assertEqual(context['odk_url'], 'https://localhost')
-
-    @mock.patch('gather.context_processors.settings.EXTERNAL_APPS',
-                {
-                    **settings.EXTERNAL_APPS,
-                    'aether-odk': {'test': {'url': 'http://localhost:8000/odk'}},
-                })
-    def test_gather_context__odk__http(self):
-        request = RequestFactory().get('/')
-        context = gather_context(request)
-        self.assertEqual(context['odk_url'], 'http://localhost:8443/odk')
 
 
 @override_settings(

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -42,7 +42,6 @@ services:
       - ./.persistent_data/static:/static
     ports:
       - 80:80
-      - 8443:8443
     healthcheck:
       test: nginx -t
       interval: 5s
@@ -237,7 +236,7 @@ services:
       AETHER_KERNEL_URL: http://aether.local/kernel
 
       AETHER_ODK_TOKEN: ${ODK_ADMIN_TOKEN}
-      AETHER_ODK_URL: http://aether.local:8443/odk
+      AETHER_ODK_URL: http://aether.local/odk
 
       DB_NAME: gather
       PGHOST: db # This matches the DB service name

--- a/local-setup/nginx/sites-enabled/aether.conf
+++ b/local-setup/nginx/sites-enabled/aether.conf
@@ -11,7 +11,6 @@
 
 server {
   listen                    80;
-  listen                    8443;  # Needed by ODK Collect
   charset                   utf-8;
   server_name               aether.local;
   client_max_body_size      75M;
@@ -75,12 +74,12 @@ server {
     proxy_pass              http://$upstream_odk:8102;
     proxy_next_upstream     error http_502;
 
-    proxy_set_header        Host               $host:8443;
+    proxy_set_header        Host               $host;
     proxy_set_header        X-Real-IP          $remote_addr;
     proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Host   $host:8443;
+    proxy_set_header        X-Forwarded-Host   $host:80;
     proxy_set_header        X-Forwarded-Server $host;
-    proxy_set_header        X-Forwarded-Port   8443;
+    proxy_set_header        X-Forwarded-Port   80;
 
     proxy_connect_timeout   300s;
     proxy_read_timeout      300s;


### PR DESCRIPTION
Depends on: https://github.com/eHealthAfrica/aether/pull/661