### PR TITLE
feat(assets): use X-Oauth-Unauthorized header

### DIFF
--- a/app/gather/assets/apps/utils/request.jsx
+++ b/app/gather/assets/apps/utils/request.jsx
@@ -27,7 +27,11 @@ const buildFetchOptions = (method, payload, multipart, extras) => {
     credentials: 'same-origin',
     headers: {
       'X-CSRFToken': csrfToken,
-      'X-METHOD': method // See comment below
+      'X-METHOD': method, // See comment below
+      // The default behavior of Kong is to redirect to the login page
+      // if the user is not authorized, with this header we try to receive
+      // the real status code "403" and redirect us to the logout page
+      'X-Oauth-Unauthorized': 'status_code'
     },
     ...extras
   }
@@ -127,6 +131,9 @@ const inspectResponse = ({ download, filename }, resolve, reject, response) => {
     return response
       .json()
       .then(content => resolve(content))
+  } else if (response.status === 403) {
+    const logoutUrl = document.getElementById('logout-link').href
+    return window.location.assign(logoutUrl)
   } else {
     const error = new Error(response.statusText)
     return response

--- a/app/gather/templates/gather/navbar.html
+++ b/app/gather/templates/gather/navbar.html
@@ -62,7 +62,7 @@ under the License.
               data-user-id="{{ request.user.id }}">
               {{ request.user|get_fullname:request }}
             </span>
-            <a class="logout" href="{{ gather_url }}{% url 'logout' %}">
+            <a id="logout-link" class="logout" href="{{ gather_url }}{% url 'logout' %}">
               <i class="fas fa-sign-out-alt" title="{% trans 'Sign Out' %}" aria-hidden="true"></i>
             </a>
           </li>


### PR DESCRIPTION
The default behavior of Kong is to redirect to the login page if the user is not authorized or not authenticated, with this header X-Oauth-Unauthorized we try to receive the real status code "403" and redirect us to the logout page.

![image](https://user-images.githubusercontent.com/8459537/67565952-e25bdd80-f726-11e9-83f9-7fb1890e2062.png)
